### PR TITLE
release_notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,21 @@ jobs:
         id: get_version
         run: echo ::set-output name=version::$(date +'%Y.%m.%d.%H%M%S')
 
+      - name: Generate release notes
+        id: generate_release_notes
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: commits } = await github.repos.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              per_page: 10
+            });
+
+            const releaseNotes = commits.map(commit => `- ${commit.commit.message}`).join('\n');
+            core.setOutput('release_notes', releaseNotes);
+
       - name: Create GitHub Release
         id: create_release
         uses: actions/create-release@v1
@@ -39,6 +54,7 @@ jobs:
         with:
           tag_name: v${{ steps.get_version.outputs.version }}
           release_name: Release ${{ steps.get_version.outputs.version }}
+          body: ${{ steps.generate_release_notes.outputs.release_notes }}
           draft: false
           prerelease: false
 


### PR DESCRIPTION
This pull request includes updates to the release workflow in the `.github/workflows/release.yml` file to automate the generation of release notes. The most important changes include adding a new step to generate release notes and updating the GitHub Release step to include the generated release notes.

Improvements to the release workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R34-R48): Added a new step to generate release notes using the `actions/github-script@v6` action. This step retrieves the latest commits and formats their messages into release notes.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R57): Updated the `Create GitHub Release` step to include the generated release notes in the release body.